### PR TITLE
BUGFIX: QA-5830 Ability to handle paralell mergeability conflict

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -62,6 +62,7 @@ import zuul.trigger.gerrit
 import zuul.trigger.github
 import zuul.trigger.timer
 import zuul.trigger.zuultrigger
+from zuul.exceptions import MergeFailure
 
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__),
                            'fixtures')
@@ -681,6 +682,7 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         self.pull_requests = []
         self.upstream_root = upstream_root
         self.merge_failure = False
+        self.merge_not_allowed_count = 0
 
     def openFakePullRequest(self, project, branch, subject, files=[]):
         self.pr_number += 1
@@ -777,6 +779,10 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         pull_request = self.pull_requests[pr_number - 1]
         if self.merge_failure:
             raise Exception('Pull request was not merged')
+        if self.merge_not_allowed_count > 0:
+            self.merge_not_allowed_count -= 1
+            raise MergeFailure('Merge was not successful due to mergeability'
+                               ' conflict')
         pull_request.is_merged = True
         pull_request.merge_message = commit_message
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -305,6 +305,24 @@ class TestGithub(ZuulTestCase):
         self.assertFalse(A.is_merged)
         self.fake_github.merge_failure = False
 
+    def test_report_pull_merge_not_allowed_once(self):
+        # pipeline merges the pull request on second run of merge
+        # first merge failed on 405 Method Not Allowed error
+        self.fake_github.merge_not_allowed_count = 1
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getCommentAddedEvent('merge me'))
+        self.waitUntilSettled()
+        self.assertTrue(A.is_merged)
+
+    def test_report_pull_merge_not_allowed_twice(self):
+        # pipeline does not merge the pull request
+        # merge failed on 405 Method Not Allowed error - twice
+        self.fake_github.merge_not_allowed_count = 2
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        self.fake_github.emitEvent(A.getCommentAddedEvent('merge me'))
+        self.waitUntilSettled()
+        self.assertFalse(A.is_merged)
+
     def test_parallel_changes(self):
         "Test that changes are tested in parallel and merged in series"
 

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -21,9 +21,11 @@ import webob
 import webob.dec
 import voluptuous as v
 import github3
+from github3.exceptions import MethodNotAllowed
 
 from zuul.connection import BaseConnection
 from zuul.model import GithubTriggerEvent
+from zuul.exceptions import MergeFailure
 
 
 class GithubWebhookListener():
@@ -313,7 +315,11 @@ class GithubConnection(BaseConnection):
     def mergePull(self, owner, project, pr_number, commit_message='',
                   sha=None):
         pull_request = self.github.pull_request(owner, project, pr_number)
-        result = pull_request.merge(commit_message=commit_message, sha=sha)
+        try:
+            result = pull_request.merge(commit_message=commit_message, sha=sha)
+        except MethodNotAllowed as e:
+            raise MergeFailure('Merge was not successful due to mergeability'
+                               ' conflict, original error is %s' % e)
         log_rate_limit(self.log, self.github)
         if not result:
             raise Exception('Pull request was not merged')


### PR DESCRIPTION
When there are multiple merges called at the same time, it leads to a
situation when github returns 405 MethodNotAllowed error becuase github
is checking the branch mergeability.

When we encounter this situation, we try to wait a bit (2 seconds for
now) and try to merge again.

It's also covered by simple tests using fake connection.
