### PR TITLE
Install and lock uritemplate.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ apscheduler>=3.0,<3.1.0
 PrettyTable>=0.6,<0.8
 babel>=1.0
 six>=1.6.0
+
+# hack around https://github.com/sigmavirus24/github3.py/issues/634
+uritemplate<3.0.1


### PR DESCRIPTION
This is a workaround for bug
https://github.com/sigmavirus24/github3.py/issues/634

Which is in fact between github3.py and uritemplate.py (which was
recently deprecated in favour of uritemplate). As a quick fix, adding
and locking this dependency to zuul as we currently don't have control
over the github3.py.

Revert once the bug in github3.py is fixed.

Change-Id: Ifdd88df7379caa400c9605026da8903ddcb6cd62