### PR TITLE
Handle dict extras in Voluptuous Schema

### DIFF
--- a/zuul/connection/gerrit.py
+++ b/zuul/connection/gerrit.py
@@ -470,5 +470,5 @@ class GerritConnection(BaseConnection):
 
 
 def getSchema():
-    gerrit_connection = v.Any(str, v.Schema({}, extra=True))
+    gerrit_connection = v.Any(str, v.Schema(dict))
     return gerrit_connection

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -355,5 +355,5 @@ def log_rate_limit(log, github):
 
 
 def getSchema():
-    github_connection = v.Any(str, v.Schema({}, extra=True))
+    github_connection = v.Any(str, v.Schema(dict))
     return github_connection

--- a/zuul/connection/smtp.py
+++ b/zuul/connection/smtp.py
@@ -59,5 +59,5 @@ class SMTPConnection(BaseConnection):
 
 
 def getSchema():
-    smtp_connection = v.Any(str, v.Schema({}, extra=True))
+    smtp_connection = v.Any(str, v.Schema(dict))
     return smtp_connection

--- a/zuul/layoutvalidator.py
+++ b/zuul/layoutvalidator.py
@@ -40,7 +40,7 @@ class LayoutSchema(object):
                          'email': str,
                          'older-than': str,
                          'newer-than': str,
-                         }, extra=True)
+                         }, extra=v.ALLOW_EXTRA)
 
     require = {'approval': toList(approval),
                'open': bool,

--- a/zuul/reporter/gerrit.py
+++ b/zuul/reporter/gerrit.py
@@ -48,5 +48,5 @@ class GerritReporter(BaseReporter):
 
 
 def getSchema():
-    gerrit_reporter = v.Any(str, v.Schema({}, extra=True))
+    gerrit_reporter = v.Any(str, v.Schema(dict))
     return gerrit_reporter

--- a/zuul/trigger/gerrit.py
+++ b/zuul/trigger/gerrit.py
@@ -82,14 +82,14 @@ def validate_conf(trigger_conf):
 def getSchema():
     def toList(x):
         return v.Any([x], x)
-    variable_dict = v.Schema({}, extra=True)
+    variable_dict = v.Schema(dict)
 
     approval = v.Schema({'username': str,
                          'email-filter': str,
                          'email': str,
                          'older-than': str,
                          'newer-than': str,
-                         }, extra=True)
+                         }, extra=v.ALLOW_EXTRA)
 
     gerrit_trigger = {
         v.Required('event'):

--- a/zuul/trigger/zuultrigger.py
+++ b/zuul/trigger/zuultrigger.py
@@ -136,7 +136,7 @@ def getSchema():
                          'email': str,
                          'older-than': str,
                          'newer-than': str,
-                         }, extra=True)
+                         }, extra=v.ALLOW_EXTRA)
 
     zuul_trigger = {
         v.Required('event'):


### PR DESCRIPTION
Not sure if schema requirements changed but it is no longer valid to
use:

  Schema({}, extra=True)

The docs say that should be avoided and instead you should use:

  Schema(dict)

To indicate a dict that can have any key: value pairs. Additionally
extra=True appears to be replaced with extra=ALLOW_EXTRA so update that
in cases where we have some subset of desired keys.

Change-Id: Ia9f4d535b9b633e703465f155c4722d9a58c45a7
(cherry picked from commit 0a38b6c5680f5c7cb23fab91dbfc84f88024829d)