### PR TITLE
SETI-866: Raise timeouts for integration tests

### DIFF
--- a/integration/spec/gerrit_workflow_spec.rb
+++ b/integration/spec/gerrit_workflow_spec.rb
@@ -67,7 +67,7 @@ class Gerrit
     @port = port
   end
 
-  def wait_change_submitted(change_number, timeout = 30)
+  def wait_change_submitted(change_number, timeout = 300)
     poll_interval = 3
     loop do
       change = query_single_change(change_number)

--- a/integration/spec/github_workflow_spec.rb
+++ b/integration/spec/github_workflow_spec.rb
@@ -66,7 +66,7 @@ describe 'Github pull request' do
   end
 end
 
-def wait_pr_merged(github, repo, pull, timeout = 30)
+def wait_pr_merged(github, repo, pull, timeout = 300)
   poll_interval = 3
   loop do
     pull = github.pull_request(repo, pull.number)


### PR DESCRIPTION
Raise the timeout for the gate to be the same as for the check, which is
5 minutes.

30 seconds was really too few.