### PR TITLE
SETI-376: Move and edit zuul.spec to build via rpmbuild-el7-tools

### DIFF
--- a/zuul.spec
+++ b/zuul.spec
@@ -4,7 +4,7 @@ Name:             zuul
 Summary:          GoodData customized Zuul gatekeeper
 Epoch:            1
 Version:          2.5.1
-Release:          %(date +%%Y%%m%%d%%H%%M%%S)%{?dist}.gdc
+Release:          %{?gdcversion}%{?dist}.gdc
 
 Vendor:           GoodData
 Group:            GoodData/Tools
@@ -47,3 +47,156 @@ GoodData customized Zuul gatekeeper
 %attr(0755, root, root) %{install_dir}/lib
 %attr(0755, root, root) %{install_dir}/lib64
 %attr(0755, root, root) %{install_dir}/status
+
+%changelog
+* Mon Aug 08 2017 Michal Vanco <michal.vanco@gooddata.com> 2.5.1-2.gdc
+- Gerrit integration test
+- Scheduler logs projects sorted by name
+- BUGFIX: SETI-380 Zuul exits when HUP is send right after service start
+- BUGFIX: SETI-384 Zuul - handle ping events
+- BUGFIX: SETI-379 zuul-cloner tries to fetch a wrong revision
+- FEATURE: SETI-668 Support custom name of status in zuul pipelines
+- BUGFIX: SETI-190 Zuul: report back to pull request when no jobs are run
+
+* Mon Dec 05 2016 Jan Hruban <jan.hruban@gooddata.com> 2.5.1-1.gdc
+- The source code is already above tag 2.5.1. Only bump the version.
+
+* Tue Dec 02 2016 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-28.gdc
+- Allow gerrit + github work together
+- Upstream changes
+
+* Tue Jun 06 2016 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-27.gdc
+- Fix quick consequent merging on github
+- Upstream changes
+
+* Wed Apr 13 2016 Yury Tsarev <yury.tsarev@gooddata.com> 2.1.1-26.gdc
+- Configurable status_url_with_change option
+- Relevant js frontend filtering change
+
+* Tue Mar 15 2016 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-25.gdc
+- Allow file matching for GitHub
+- Log GitHub API Rate
+- Upstream changes
+
+* Tue Feb 16 2016 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-24.gdc
+- Include title in github commit message
+- Include Reviewed-by in github commit message
+- Upstream changes
+
+* Thu Dec 16 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-23.gdc
+- Allow github trigger to match on branches/refs
+- Rebase onto upstream changes
+
+* Thu Nov 20 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-22.gdc
+- Fix handling the label events
+
+* Thu Nov 19 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-21.gdc
+- Sync with upstream changes.
+- Add label support for github trigger and reporter.
+- Implement dependent pipelines for github.
+- Enable the dequeue mechanism.
+
+* Thu Nov 18 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-20.gdc
+- Fix permissions of the git dir in post-install. Related to the umask fix in 2.1.1-17.
+
+* Thu Nov 16 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-19.gdc
+- Sync with upstream changes. Creating the zuul-merger dir incorporated, supersedes 7cf9ebd
+- Revert the backwards compatibility changes for the configuration options
+
+* Thu Nov 13 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-18.gdc
+- Fix zuul-merger not creating the git_dir on start, which fails on new deployments
+- Sync with upstream changes (from now only merges into this repo, no rebases)
+
+* Thu Nov 13 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-17.gdc
+- Respect PPID umask when daemonizing
+
+* Thu Nov 13 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-16.gdc
+- Package 2.1.1-15 was mistakenly built on top of 2.1.1-14 instead of
+  2.1.1-14.1. Rebuild with the correct content.
+
+* Thu Nov 10 2015 Yury Tsarev <yury.tsarev@gooddata.com> 2.1.1-15.gdc
+- Include web assets into package
+
+* Wed Nov 03 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-14.1.gdc
+- Fix the backward compatibility
+- Fix the layout validation tool until upstream does
+
+* Wed Nov 03 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-14.gdc
+- Rebase onto upstream changes
+- Change of the github reporter defaults
+- Change name of configuration option in github reporter (backwards compatible)
+- Change in the ssh configuration
+- Built on top of:
+  git fetch https://github.com/gooddata/zuul refs/heads/compat/github-integration-status
+
+* Wed Nov 03 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-13.gdc
+- github3.py >=1.0.0 has different API, fix a bug resulting from such incompatibility
+- Built on top of:
+  git fetch https://github.com/gooddata/zuul refs/heads/not-in-review/github-integration/5
+
+* Wed Nov 03 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-12.gdc
+- Support merging pull requests from github reporter
+- Depend on pre-release version on github3.py 1.0.0a2 (fixes merging PRs)
+- Built on top of:
+  git fetch https://github.com/gooddata/zuul refs/heads/not-in-review/github-integration/4
+
+* Wed Oct 29 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-11.gdc
+- Fix minor test glitch
+- Update authorship of commits
+- Built on top of:
+  git fetch https://github.com/gooddata/zuul refs/heads/not-in-review/github-integration/3
+
+* Wed Oct 27 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-10.gdc
+- Enforce the config schema of the github reporter
+- Built on top of:
+  git fetch https://github.com/gooddata/zuul refs/heads/not-in-review/github-integration/2
+
+* Wed Oct 27 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-9.gdc
+- Make the github statuses configurable, with sane defaults
+- Improve the github statuses & comment testing
+- Fix github-ssh documentation
+- Built on top of:
+  git fetch https://github.com/gooddata/zuul refs/heads/not-in-review/github-integration/1
+
+* Wed Oct 26 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-8.gdc
+- Set Github statuses
+- Built on top of:
+  git fetch https://review.openstack.org/openstack-infra/zuul refs/changes/03/239303/6 && git checkout FETCH_HEAD
+
+* Wed Oct 26 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-7.gdc
+- Fix SSH URL
+- Built on top of:
+  git fetch https://review.openstack.org/openstack-infra/zuul refs/changes/38/239138/7 && git checkout FETCH_HEAD
+
+* Wed Oct 26 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-6.gdc
+- Allow access to private repositories via SSH
+- Built on top of:
+  git fetch https://review.openstack.org/openstack-infra/zuul refs/changes/38/239138/6 && git checkout FETCH_HEAD
+
+* Wed Oct 26 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-5.gdc
+- Fix the construction of messages in the reporter
+- Built on top of:
+  git fetch https://review.openstack.org/openstack-infra/zuul refs/changes/03/239203/5 && git checkout FETCH_HEAD
+
+* Wed Oct 26 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-4.gdc
+- Fix the pr-comment handling
+- More debugging output
+- Built on top of:
+  git fetch https://review.openstack.org/openstack-infra/zuul refs/changes/03/239203/4 && git checkout FETCH_HEAD
+
+* Wed Oct 26 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-3.gdc
+- Support to trigger jobs on github pull request comments
+- GitHub change support for patchset
+- Link to pull request in job descriptions
+- Built on top of:
+  git fetch https://review.openstack.org/openstack-infra/zuul refs/changes/03/239203/3 && git checkout FETCH_HEAD
+
+* Wed Sep 14 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1.dev76-1.gdc
+- Adding GitHub tests
+- Base versioning scheme on `zuul --version'
+
+* Wed Aug 12 2015 Jan Hruban <jan.hruban@gooddata.com> 2.1.1-2.gdc
+- Better webhook event handling in the github integration
+
+* Wed Aug 12 2015 Yury Tsarev <yury.tsarev@gooddata.com> 2.1.1-1.gdc
+- First Zuul build - customized github integration included


### PR DESCRIPTION
Right now we build zuul on two different places: 1. as a part of testing pipeline through gooddata/zuul/zuul.spec, 2. production version through gdc-generic-bundle/packages/zuul/files/zuul.spec. Let's get rid of the spec file in gdc-generic-bundle, so the building is unified and less prone to error.
