### PR TITLE
 SETI-1210: Zuul can mix PRs from different projects

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -701,7 +701,7 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         super(FakeGithubConnection, self).__init__(connection_name,
                                                    connection_config)
         self.connection_name = connection_name
-        self.pr_number = 0
+        self.pr_number = {}
         self.pull_requests = []
         self.upstream_root = upstream_root
         self.merge_failure = False
@@ -709,10 +709,10 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
         self.files = {}
 
     def openFakePullRequest(self, project, branch, subject, files=[]):
-        self.pr_number += 1
+        self.pr_number[project] = self.pr_number.setdefault(project, 0) + 1
         pull_request = FakeGithubPullRequest(
-            self, self.pr_number, project, branch, subject, self.upstream_root,
-            files=files)
+            self, self.pr_number[project], project, branch,
+            subject, self.upstream_root, files=files)
         self.pull_requests.append(pull_request)
         return pull_request
 

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -993,7 +993,7 @@ class PullRequest(Change):
         if (hasattr(other, 'number') and self.number == other.number and
             hasattr(other, 'patchset') and self.patchset != other.patchset and
             hasattr(other, 'updated_at') and
-            self.updated_at > other.updated_at):
+            self.updated_at >= other.updated_at):
             return True
         return False
 

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -990,7 +990,8 @@ class PullRequest(Change):
         self.title = None
 
     def isUpdateOf(self, other):
-        if (hasattr(other, 'number') and self.number == other.number and
+        if (hasattr(other, 'project') and self.project == other.project and
+            hasattr(other, 'number') and self.number == other.number and
             hasattr(other, 'patchset') and self.patchset != other.patchset and
             hasattr(other, 'updated_at') and
             self.updated_at >= other.updated_at):


### PR DESCRIPTION
Zuul only checks changes by PR number when deleting the old ones.
Check project name too in isUpdateOf()