### PR TITLE
TRIVIAL: Raise timeouts for individual tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = pep8, py27
 setenv = STATSD_HOST=127.0.0.1
          STATSD_PORT=8125
          VIRTUAL_ENV={envdir}
-         OS_TEST_TIMEOUT=30
+         OS_TEST_TIMEOUT=60
          OS_LOG_DEFAULTS={env:OS_LOG_DEFAULTS:gear.Server=INFO,gear.Client=INFO}
 passenv = ZUUL_TEST_ROOT
 usedevelop = True


### PR DESCRIPTION
Recently, unit tests for zuul started to fail on CI because of
timeouts. This should solve it.