### PR TITLE
tox.ini: Set python version for testenvs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 envlist = pep8, py27
 
 [testenv]
+basepython = python2.7
 # Set STATSD env variables so that statsd code paths are tested.
 setenv = STATSD_HOST=127.0.0.1
          STATSD_PORT=8125


### PR DESCRIPTION
tox can use python3 otherwise (and it will on current debian).