### PR TITLE
SETI-1023: extract filenames after push event correctly

### DIFF
--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -315,7 +315,7 @@ class GithubConnection(BaseConnection):
         comparison = \
             self.github.repository(owner, project).compare_commits(oldrev,
                                                                    newrev)
-        filenames = [f.filename for f in comparison]
+        filenames = [f['filename'] for f in comparison.files]
         return filenames
 
     def getUser(self, login):


### PR DESCRIPTION
It works like this:
```
> gh = github3.login('mytoken')
> repo = gh.repository('gooddata', 'ci-infra')
> [f['filename'] for f in repo.compare_commits('c403edb', '4d73941').files]
[u'.jenkins-jobs.ini.tpl', u'jenkins/jobs/templates/util-jobs.yaml']
```