### PR TITLE
SETI-1306: Correct Change, NullChange, Ref equals() functions

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -150,3 +150,25 @@ class TestTimeDataBase(BaseTestCase):
         for x in range(10):
             self.db.update('job-name', 100, 'SUCCESS')
         self.assertEqual(self.db.getEstimatedTime('job-name'), 100)
+
+
+class TestChangeish(BaseTestCase):
+    """Tests Changeish and its child classes"""
+
+    def test_inequality(self):
+        """Test that checking for equality of diffferent
+        classes does not throw exceptions"""
+        change = model.Change("project1")
+        change.number = 4
+        change.patchset = 10
+        ref = model.Ref("project1")
+        ref.ref = 'origin/master'
+        ref.newrev = 1234
+        nullchange = model.NullChange("project1")
+
+        self.assertFalse(change.equals(ref))
+        self.assertFalse(change.equals(nullchange))
+        self.assertFalse(ref.equals(change))
+        self.assertFalse(ref.equals(nullchange))
+        self.assertFalse(nullchange.equals(change))
+        self.assertFalse(nullchange.equals(ref))

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -960,7 +960,10 @@ class Change(Changeish):
         return '<Change 0x%x %s>' % (id(self), self._id())
 
     def equals(self, other):
-        if self.number == other.number and self.patchset == other.patchset:
+        if (all([hasattr(other, attr) for attr in ['number', 'patchset']])
+            and self.project == other.project
+            and self.number == other.number
+            and self.patchset == other.patchset):
             return True
         return False
 
@@ -1025,7 +1028,8 @@ class Ref(Changeish):
         return rep
 
     def equals(self, other):
-        if (self.project == other.project
+        if (all([hasattr(other, attr) for attr in ['ref', 'newref']])
+            and self.project == other.project
             and self.ref == other.ref
             and self.newrev == other.newrev):
             return True


### PR DESCRIPTION
Let's check for existence of attributes in the other object first
to avoid exceptions in equals(self, other) function.
Also check for project attribute in Change.equals (bugfix).