### PR TITLE
SETI-1706: Check that SHA of PR head fetched by merger is correct

### DIFF
--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -659,3 +659,8 @@ class TestGithub(ZuulTestCase):
         self.waitUntilSettled()
 
         self.assertEqual(A.statuses['check']['state'], 'failure')
+
+        sha_mismatch_msg = "Github ref error: SHA of pull request head " \
+                           "checked out from remote PR head ref is different" \
+                           " from head commit SHA from Github webhook event."
+        self.assertIn(sha_mismatch_msg, A.comments)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -641,3 +641,21 @@ class TestGithub(ZuulTestCase):
         self.assertIn("Error merging pull request:"
                       " Head branch was modified.", A.comments)
         self.assertEqual(False, A.is_merged)
+
+    def test_head_commit_sha_mismatch(self):
+        """
+        Test that zuul fails when trying to merge different head commit
+        than that in webhook JSON
+        """
+
+        A = self.fake_github.openFakePullRequest('org/project', 'master', 'A')
+        old_sha = A.head_sha
+        A.addCommit()
+
+        A.head_sha = old_sha
+        event = A.getPullRequestOpenedEvent()
+
+        self.fake_github.emitEvent(event)
+        self.waitUntilSettled()
+
+        self.assertEqual(A.statuses['check']['state'], 'failure')

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -203,6 +203,7 @@ class GithubWebhookListener():
         event.updated_at = pr_body.get('updated_at')
         event.branch = base.get('ref')
         event.refspec = "refs/pull/" + str(pr_body.get('number')) + "/head"
+        event.refspec_sha = head.get('sha')
         event.patch_number = head.get('sha')
 
         event.title = pr_body.get('title')

--- a/zuul/exceptions.py
+++ b/zuul/exceptions.py
@@ -37,3 +37,11 @@ class MergeFailure(Exception):
 
 class HeadBranchModified(Exception):
     pass
+
+
+class ExpectedSHAMismatch(Exception):
+    def __init__(self, expected_sha="", actual_sha=""):
+        self.message = "Merger did not fetch expected head " \
+                       "commit: expected %s, actual %s" % \
+                       (expected_sha, actual_sha)
+        super(ExpectedSHAMismatch, self).__init__(self.message)

--- a/zuul/merger/client.py
+++ b/zuul/merger/client.py
@@ -109,13 +109,15 @@ class MergeClient(object):
             data = getJobData(job)
             zuul_url = data.get('zuul_url')
             merged = data.get('merged', False)
+            sha_match_ok = data.get('sha_match_ok', True)
             updated = data.get('updated', False)
             commit = data.get('commit')
             self.log.info("Merge %s complete, merged: %s, updated: %s, "
-                          "commit: %s" %
-                          (job, merged, updated, build_set.commit))
+                          "commit: %s, sha_match_ok: %s" %
+                          (job, merged, updated, build_set.commit,
+                           sha_match_ok))
             self.sched.onMergeCompleted(build_set, zuul_url,
-                                        merged, updated, commit)
+                                        merged, updated, commit, sha_match_ok)
             # The test suite expects the build_set to be removed from
             # the internal dict after the wake flag is set.
             del self.build_sets[job.unique]

--- a/zuul/merger/server.py
+++ b/zuul/merger/server.py
@@ -104,10 +104,13 @@ class MergeServer(object):
         args = json.loads(job.arguments)
         try:
             commit = self.merger.mergeChanges(args['items'])
+            sha_match_ok = True
         except ExpectedSHAMismatch:
             commit = None
+            sha_match_ok = False
         result = dict(merged=(commit is not None),
                       commit=commit,
+                      sha_match_ok=sha_match_ok,
                       zuul_url=self.zuul_url)
         job.sendWorkComplete(json.dumps(result))
 

--- a/zuul/merger/server.py
+++ b/zuul/merger/server.py
@@ -20,6 +20,7 @@ import traceback
 import gear
 
 from zuul.merger import merger
+from zuul.exceptions import ExpectedSHAMismatch
 
 
 class MergeServer(object):
@@ -101,7 +102,10 @@ class MergeServer(object):
 
     def merge(self, job):
         args = json.loads(job.arguments)
-        commit = self.merger.mergeChanges(args['items'])
+        try:
+            commit = self.merger.mergeChanges(args['items'])
+        except ExpectedSHAMismatch:
+            commit = None
         result = dict(merged=(commit is not None),
                       commit=commit,
                       zuul_url=self.zuul_url)

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -944,6 +944,7 @@ class Change(Changeish):
         self.url = None
         self.patchset = None
         self.refspec = None
+        self.refspec_sha = None
 
         self.needs_changes = []
         self.needed_by_changes = []
@@ -1095,6 +1096,7 @@ class TriggerEvent(object):
         self.change_url = None
         self.patch_number = None
         self.refspec = None
+        self.refspec_sha = None
         self.approvals = []
         self.branch = None
         self.comment = None

--- a/zuul/model.py
+++ b/zuul/model.py
@@ -210,6 +210,9 @@ class Pipeline(object):
             return False
         return True
 
+    def didSHAMatch(self, item):
+        return item.current_build_set.sha_match_ok
+
     def didAnyJobFail(self, item):
         for job in self.getJobs(item):
             if not job.voting:
@@ -647,6 +650,7 @@ class BuildSet(object):
         self.commit = None
         self.zuul_url = None
         self.unable_to_merge = False
+        self.sha_match_ok = True
         self.failing_reasons = []
         self.merge_state = self.NEW
 

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -1551,6 +1551,7 @@ class BasePipelineManager(object):
                     connection_name=connection_name,
                     merge_mode=item.change.project.merge_mode,
                     refspec=item.change.refspec,
+                    refspec_sha=item.change.refspec_sha,
                     branch=item.change.branch,
                     ref=item.current_build_set.ref,
                     number=number,

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -218,12 +218,14 @@ class MergeCompletedEvent(ResultEvent):
     :arg str commit: The SHA of the merged commit (changes with refs).
     """
 
-    def __init__(self, build_set, zuul_url, merged, updated, commit):
+    def __init__(self, build_set, zuul_url, merged, updated, commit,
+                 sha_match_ok=True):
         self.build_set = build_set
         self.zuul_url = zuul_url
         self.merged = merged
         self.updated = updated
         self.commit = commit
+        self.sha_match_ok = sha_match_ok
 
 
 def toList(item):
@@ -751,11 +753,12 @@ class Scheduler(threading.Thread):
         self.wake_event.set()
         self.log.debug("Done adding complete event for build: %s" % build)
 
-    def onMergeCompleted(self, build_set, zuul_url, merged, updated, commit):
+    def onMergeCompleted(self, build_set, zuul_url, merged, updated, commit,
+                         sha_match_ok=True):
         self.log.debug("Adding merge complete event for build set: %s" %
                        build_set)
         event = MergeCompletedEvent(build_set, zuul_url,
-                                    merged, updated, commit)
+                                    merged, updated, commit, sha_match_ok)
         self.result_event_queue.put(event)
         self.wake_event.set()
 
@@ -1779,6 +1782,10 @@ class BasePipelineManager(object):
         if not build_set.commit and not isinstance(item.change, NullChange):
             self.log.info("Unable to merge change %s" % item.change)
             self.pipeline.setUnableToMerge(item)
+            if not event.sha_match_ok:
+                self.log.error("Head commit SHA mismatch when merging %s"
+                               % item.change)
+                build_set.sha_match_ok = False
 
     def reportItem(self, item):
         if not item.reported:
@@ -1812,6 +1819,7 @@ class BasePipelineManager(object):
     def _reportItem(self, item):
         self.log.debug("Reporting change %s" % item.change)
         ret = True  # Means error as returned by trigger.report
+        custom_msg = None
         if item.aborted:
             self.log.debug("aborted %s" % self.pipeline.abort_actions)
             actions = self.pipeline.abort_actions
@@ -1831,6 +1839,10 @@ class BasePipelineManager(object):
         elif not self.pipeline.didMergerSucceed(item):
             actions = self.pipeline.merge_failure_actions
             item.setReportedResult('MERGER_FAILURE')
+            if not self.pipeline.didSHAMatch(item):
+                custom_msg = "Github ref error: SHA of pull request head " \
+                             "checked out from remote PR head ref is different" \
+                             " from head commit SHA from Github webhook event."
         else:
             actions = self.pipeline.failure_actions
             item.setReportedResult('FAILURE')
@@ -1847,7 +1859,8 @@ class BasePipelineManager(object):
             try:
                 self.log.info("Reporting item %s, actions: %s" %
                               (item, actions))
-                ret = self.sendReport(actions, self.pipeline.source, item)
+                ret = self.sendReport(actions, self.pipeline.source,
+                                      item, custom_msg)
                 if ret:
                     self.log.error("Reporting item %s received: %s" %
                                    (item, ret))

--- a/zuul/source/github.py
+++ b/zuul/source/github.py
@@ -54,6 +54,7 @@ class GithubSource(BaseSource):
             change = PullRequest(project)
             change.number = event.change_number
             change.refspec = event.refspec
+            change.refspec_sha = event.refspec_sha
             change.branch = event.branch
             change.url = event.change_url
             change.updated_at = self._ghTimestampToDate(event.updated_at)


### PR DESCRIPTION
git ref pull/X/head is sometimes wrong (error of Github).
Catch these errors by checking that SHA of commit fetched by merger
equals SHA of PR head acquired from Github webhook event JSON.