### PR TITLE
BUGFIX: SETI-1767 github reporter: report status and labels before merge

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -503,6 +503,7 @@ class FakeGithubPullRequest(object):
         self.comments = []
         self.labels = []
         self.statuses = {}
+        self.required_statuses = {}
         self.updated_at = None
         self.head_sha = None
         self.is_merged = False
@@ -829,6 +830,11 @@ class FakeGithubConnection(zuul.connection.github.GithubConnection):
                   sha=None):
         self.api_called(2, 'mergePull')
         pull_request = self._getPullRequest(owner, project, pr_number)
+        for s, v in pull_request.required_statuses.items():
+            if (s not in pull_request.statuses or
+                pull_request.statuses[s]['state'] != v):
+                raise Exception('Merge is not allowed: all required status '
+                                'checks did not succeed')
         if self.merge_failure:
             raise Exception('Pull request was not merged')
         if self.merge_not_allowed_count > 0:

--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -49,6 +49,12 @@ class GithubReporter(BaseReporter):
 
     def report(self, source, pipeline, item, message=None):
         """Comment on PR and set commit status."""
+        if (self._set_commit_status and
+            hasattr(item.change, 'patchset') and
+            item.change.patchset is not None):
+            self.setPullStatus(pipeline, item)
+        if self._labels:
+            self.setLabels(item)
         if (self._merge and
             hasattr(item.change, 'number')):
             try:
@@ -59,12 +65,6 @@ class GithubReporter(BaseReporter):
                 raise
         if self._create_comment:
             self.addPullComment(pipeline, item, message)
-        if (self._set_commit_status and
-            hasattr(item.change, 'patchset') and
-            item.change.patchset is not None):
-            self.setPullStatus(pipeline, item)
-        if self._labels:
-            self.setLabels(item)
 
     def addPullComment(self, pipeline, item, message):
         if message is None:


### PR DESCRIPTION
As part of SETI-377, order of reporting items to github PR was changed
to report failure more easily in case of merge failure.
Particularly, reported was supposed to merge the PR and then change
the pipeline status. This does not work on protected branches:
required status needs to be reported first and then merging is allowed
by Github.

Let's change the order of reporting, so that reporter reports status and
labels first and then merge the PR. Comment reporting happens after
merging PR to prevent reporting 2 comments (first "Merge successful",
second "Merge failed") which would be confusing.