### PR TITLE
avoid exception in github post file-filter test

### DIFF
--- a/tests/fixtures/layout-github.yaml
+++ b/tests/fixtures/layout-github.yaml
@@ -145,7 +145,5 @@ projects:
   - name: org/project1
     check:
       - project-testfile
-
-  - name: org/post-file-project
     post:
       - project-testfile

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -167,7 +167,7 @@ class TestGithub(ZuulTestCase):
         old_sha = random_sha1()
         new_sha = random_sha1()
         self.fake_github.emitEvent(
-            self.fake_github.getPushEvent('org/post-file-project', 'master',
+            self.fake_github.getPushEvent('org/project1', 'master',
                                           old_sha, new_sha, ['c-requires']))
         self.waitUntilSettled()
 
@@ -178,7 +178,7 @@ class TestGithub(ZuulTestCase):
         old_sha = random_sha1()
         new_sha = random_sha1()
         self.fake_github.emitEvent(
-            self.fake_github.getPushEvent('org/post-file-project', 'master',
+            self.fake_github.getPushEvent('org/project1', 'master',
                                           old_sha, new_sha, ['a.c', 'foobar']))
         self.waitUntilSettled()
 


### PR DESCRIPTION
One has to test on repository which is created in tests/base.py. Repo
post-file-project was not there, so it resulted in this exception being
logged in testr output:

    stderr: 'fatal: repository '/tmp/tmpwGKy8Z/zuul-test/upstream/org/post-file-project' does not exist

It was not fatal for the test, however it's confusing when searching for