### PR TITLE
TRIVIAL: Lock gear dependency to 0.11.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ python-daemon>=2.0.4,<2.1.0
 extras
 statsd>=1.0.0,<3.0
 voluptuous>=0.7
-gear>=0.5.7,<1.0.0
+gear==0.11.1
 apscheduler>=3.0,<3.1.0
 PrettyTable>=0.6,<0.8
 babel>=1.0


### PR DESCRIPTION
gear package was recently updated to 0.12.0 and does not work
with zuul anymore. Lock the version to 0.11.1, which works fine.