### PR TITLE
fix pep8 violations

### DIFF
--- a/zuul/cmd/server.py
+++ b/zuul/cmd/server.py
@@ -129,7 +129,8 @@ class Server(zuul.cmd.ZuulApp):
             else:
                 host = None
             if self.config.has_option('gearman_server', 'keepalive'):
-                keepalive = self.config.getboolean('gearman_server', 'keepalive')
+                keepalive = self.config.getboolean('gearman_server',
+                                                   'keepalive')
             else:
                 keepalive = False
             zuul.lib.gearserver.GearServer(4730,

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -1694,7 +1694,7 @@ class BasePipelineManager(object):
             skipped_jobs = self.pipeline.getSkippedJobs(item)
             if skipped_jobs:
                 self.log.debug("Skipped following jobs due to job filters for "
-                              "change %s : %s" % (item.change, skipped_jobs))
+                               "change %s : %s" % (item.change, skipped_jobs))
             try:
                 self.reportItem(item)
             except exceptions.MergeFailure:


### PR DESCRIPTION
They were introduced by
  0845c53daa87d602af7e96d4cb003bee2bcc17b0
  2c9343aa225264f97ca3c1c0273f0daca2eb089e

No idea how did they passed the tests and the Jenkins builds do not
exist anymore for investigating.