### PR TITLE
TRIVIAL: Increase timeouts in testing environment

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1714,7 +1714,7 @@ class ZuulTestCase(BaseTestCase):
         self.log.debug("Waiting until settled...")
         start = time.time()
         while True:
-            if time.time() - start > 10:
+            if time.time() - start > 20:
                 self.log.debug("Queue status:")
                 for queue in self.event_queues:
                     self.log.debug("  %s: %s" % (queue, queue.empty()))

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = pep8, py27
 setenv = STATSD_HOST=127.0.0.1
          STATSD_PORT=8125
          VIRTUAL_ENV={envdir}
-         OS_TEST_TIMEOUT=60
+         OS_TEST_TIMEOUT=200
          OS_LOG_DEFAULTS={env:OS_LOG_DEFAULTS:gear.Server=INFO,gear.Client=INFO}
 passenv = ZUUL_TEST_ROOT
 usedevelop = True


### PR DESCRIPTION
Our testing infrastructure is sometimes too slow to run more
complex tests in time.
Increase timeout in function waitUntilSettled from 10 to 20 sec.
Increase overall timeout for every test from 60 to 150 sec.