### PR TITLE
TRIVIAL: Bump github3.py version from 1.0.0a2 to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pbr>=1.1.0
 
 argparse
-Github3.py==1.0.0a2
+Github3.py>=1.3.0
 PyYAML>=3.1.0
 Paste<2.0
 WebOb>=1.2.3


### PR DESCRIPTION
Before this commit, an alpha version fo github3.py library was
used because some new features yet under development were used.

The situation has changed and github3.py has released a few stable
versions since then. Let's bump the library version so we do not
use an unstable version.

Release notes were checked and there are no changes needed in
zuul/connection/github.py (the only place github3.py is used).