### PR TITLE
TRIVIAL: Increase test timeout

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = pep8, py27
 setenv = STATSD_HOST=127.0.0.1
          STATSD_PORT=8125
          VIRTUAL_ENV={envdir}
-         OS_TEST_TIMEOUT=200
+         OS_TEST_TIMEOUT=400
          OS_LOG_DEFAULTS={env:OS_LOG_DEFAULTS:gear.Server=INFO,gear.Client=INFO}
 passenv = ZUUL_TEST_ROOT
 usedevelop = True


### PR DESCRIPTION
Increase test timeout so GD infrastructure can run the tests
without hitting the timeout.