### PR TITLE
SETI-2852: Fix zuul status page URLs in github status checks

### DIFF
--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -265,7 +265,7 @@ class TestGithub(ZuulTestCase):
         self.waitUntilSettled()
         self.assertIn('check', A.statuses)
         check_status = A.statuses['check']
-        check_url = ('http://zuul.example.com/status/#%s,%s' %
+        check_url = ('http://zuul.example.com/status/#%s_%s' %
                      (A.number, A.head_sha))
         self.assertEqual('Standard check', check_status['description'])
         self.assertEqual('pending', check_status['state'])

--- a/zuul/reporter/github.py
+++ b/zuul/reporter/github.py
@@ -86,7 +86,9 @@ class GithubReporter(BaseReporter):
             self.sched.config.has_option('zuul', 'status_url')):
             url = self.sched.config.get('zuul', 'status_url')
             if self.sched.config.has_option('zuul', 'status_url_with_change'):
-                url = '%s/#%s' % (url, item.change)
+                # format change id into zuul status page filter string
+                filter_string = item.change._id().replace(',', '_')
+                url = '%s/#%s' % (url, filter_string)
         description = ''
         if pipeline.description:
             description = pipeline.description


### PR DESCRIPTION
Github reporter displays URL to zuul status page with filter for
the current PR's build. The filter string format was broken. This
commit fixes the format.