### PR TITLE
SETI-1707: Update default merge_failure message

### DIFF
--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3552,10 +3552,11 @@ see http://wiki.example.org/Test_Failures",
         self.registerJobs()
 
         self.assertEqual(
-            "Merge Failed.\n\nThis change or one of its cross-repo "
-            "dependencies was unable to be automatically merged with the "
-            "current state of its repository. Please rebase the change and "
-            "upload a new patchset.",
+            "Merge Failed.\n\nZuul merger could "
+            "not merge this change into the base branch. This is most "
+            "likely caused by merge conflicts. Please rebase the change "
+            "and upload the rebased version. In case of further errors, "
+            "contact the zuul administrator.",
             self.sched.layout.pipelines['check'].merge_failure_message)
         self.assertEqual(
             "The merge failed! For more information...",
@@ -3644,7 +3645,6 @@ see http://wiki.example.org/Test_Failures",
         self.assertEqual(B.data['status'], 'NEW')
         self.assertIn('Build succeeded', A.messages[1])
         self.assertIn('Merge Failed', B.messages[1])
-        self.assertIn('automatically merged', B.messages[1])
         self.assertNotIn('logs.example.com', B.messages[1])
         self.assertNotIn('SKIPPED', B.messages[1])
 

--- a/tests/test_zuultrigger.py
+++ b/tests/test_zuultrigger.py
@@ -107,10 +107,11 @@ class TestZuulTrigger(ZuulTestCase):
         self.assertEqual(E.reported, 0)
         self.assertEqual(
             B.messages[0],
-            "Merge Failed.\n\nThis change or one of its cross-repo "
-            "dependencies was unable to be automatically merged with the "
-            "current state of its repository. Please rebase the change and "
-            "upload a new patchset.")
+            "Merge Failed.\n\nZuul merger could "
+            "not merge this change into the base branch. This is most "
+            "likely caused by merge conflicts. Please rebase the change "
+            "and upload the rebased version. In case of further errors, "
+            "contact the zuul administrator.")
 
         self.assertTrue("project:org/project status:open" in
                         self.fake_gerrit.queries)
@@ -134,9 +135,10 @@ class TestZuulTrigger(ZuulTestCase):
         self.assertEqual(E.reported, 1)
         self.assertEqual(
             E.messages[0],
-            "Merge Failed.\n\nThis change or one of its cross-repo "
-            "dependencies was unable to be automatically merged with the "
-            "current state of its repository. Please rebase the change and "
-            "upload a new patchset.")
+            "Merge Failed.\n\nZuul merger could "
+            "not merge this change into the base branch. This is most "
+            "likely caused by merge conflicts. Please rebase the change "
+            "and upload the rebased version. In case of further errors, "
+            "contact the zuul administrator.")
         self.assertEqual(self.fake_gerrit.queries[1],
                          "project:org/project status:open")

--- a/zuul/scheduler.py
+++ b/zuul/scheduler.py
@@ -445,11 +445,11 @@ class Scheduler(threading.Thread):
             pipeline.failure_message = conf_pipeline.get('failure-message',
                                                          "Build failed.")
             pipeline.merge_failure_message = conf_pipeline.get(
-                'merge-failure-message', "Merge Failed.\n\nThis change or one "
-                "of its cross-repo dependencies was unable to be "
-                "automatically merged with the current state of its "
-                "repository. Please rebase the change and upload a new "
-                "patchset.")
+                'merge-failure-message', "Merge Failed.\n\nZuul merger could "
+                "not merge this change into the base branch. This is most "
+                "likely caused by merge conflicts. Please rebase the change "
+                "and upload the rebased version. In case of further errors, "
+                "contact the zuul administrator.")
             pipeline.success_message = conf_pipeline.get('success-message',
                                                          "Build succeeded.")
             pipeline.footer_message = conf_pipeline.get('footer-message', "")


### PR DESCRIPTION
merge_failure message is reported to github PR in case zuul-merger
fails to merge the change into base branch. This usually happens
in case of merge conflicts. Otherwise, it is usually an error in
zuul-merger.

Update the merge_failure message so it accurately describes the
situation.