### PR TITLE
BUGFIX: Add missing installed files to specfile

### DIFF
--- a/zuul.spec
+++ b/zuul.spec
@@ -51,6 +51,7 @@ GoodData customized Zuul gatekeeper
 %attr(0755, root, root) %{install_dir}/lib
 %attr(0755, root, root) %{install_dir}/lib64
 %attr(0755, root, root) %{install_dir}/status
+%attr(0755, root, root) %{install_dir}/share
 
 %changelog
 * Tue Apr 09 2019 Jan Priessnitz <jan.priessnitz@gooddata.com> 2.5.2-1.gdc


### PR DESCRIPTION
There are two new files installed, but not packaged to rpm. Let's add it
into specfile.

Fix for rpmbuild error
error: Installed (but unpackaged) file(s) found:
    /opt/gdc/zuul/share/doc/jwcrypto/LICENSE
    /opt/gdc/zuul/share/doc/jwcrypto/README.md