### PR TITLE
Revert "CONFIG: SETI-3262 Change logging stream from stderr to stdout for script zuul-clear-refs"

### DIFF
--- a/tools/zuul-clear-refs.py
+++ b/tools/zuul-clear-refs.py
@@ -50,7 +50,7 @@ parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
 parser.add_argument('gitrepo', help='path to a Zuul git repository')
 args = parser.parse_args()
 
-logging.basicConfig(stream=sys.stdout)
+logging.basicConfig()
 log = logging.getLogger('zuul-clear-refs')
 if args.verbose:
     log.setLevel(logging.DEBUG)


### PR DESCRIPTION
Reverts gooddata/zuul#89
if we go this way we also need to update crontab in zuul to check exit code otherwise it will ignore also case script exited with failure. So this solution will be more better : https://github.com/gooddata/puppet/pull/34801/files 