### PR TITLE
SETI-3922: Upgrade requirements for GitPython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ PyYAML>=3.1.0
 Paste<2.0
 WebOb>=1.2.3
 paramiko>=1.8.0,<2.0.0
-GitPython==2.1.9
+GitPython>=2.1.9
 ordereddict
 python-daemon>=2.0.4,<2.1.0
 extras


### PR DESCRIPTION
The version 2.1.9 of GitPython is not available in PIP anymore. But we can safely use newer versions as tested here: https://checklist.intgdc.com/job/ci-infra/job/ci-infra-compare-jobs/4658/console

I have checked that these version are not used on zuul main server (the GitPython package there is installed from RPMs).