### PR TITLE
SETI-5534: Lock Github3.py version to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pbr>=1.1.0
 
 argparse
-Github3.py>=1.3.0
+Github3.py==1.3.0
 PyYAML>=3.1.0
 Paste<2.0
 WebOb>=1.2.3


### PR DESCRIPTION
As newer version require higher python version and may
break other integration

Proper solution will be done in SETI-3827