### PR TITLE
SETI-5687 Move the sleep after hooking to __dispatch_event()

### DIFF
--- a/zuul.spec
+++ b/zuul.spec
@@ -3,7 +3,7 @@
 Name:             zuul
 Summary:          GoodData customized Zuul gatekeeper
 Epoch:            1
-Version:          2.5.3
+Version:          2.5.4
 Release:          %{?gdcversion}%{?dist}.gdc
 
 Vendor:           GoodData
@@ -56,6 +56,10 @@ GoodData customized Zuul gatekeeper
 %attr(0755, root, root) %{install_dir}/tools
 
 %changelog
+* Thur Apr 15 2021 Hung Cao <hung.cao@gooddata.com> - 2.5.4
+- SETI-5687 Move the sleep after hooking to __dispatch_event()
+- Where it can be applied for all events instead of only the PR creating event
+
 * Fri Apr 09 2021 Hung Cao <hung.cao@gooddata.com> - 2.5.3
 - SETI-5687 Sleep 2s after hook is deliver and before zuul fetch PR
 - Temporarily disable test/check until it's fixed

--- a/zuul/connection/github.py
+++ b/zuul/connection/github.py
@@ -65,6 +65,11 @@ class GithubWebhookListener():
             raise webob.exc.HTTPBadRequest(message)
 
         try:
+            # After github hook is sent, we need to wait for 2s for the cache
+            # in github is synced
+            # This would prevent 404 error when PR changed its state
+            sleep(2)
+            self.log.info("2s sleep for github ref is synced")
             event = method(request)
         except:
             self.log.exception('Exception when handling event:')
@@ -110,11 +115,6 @@ class GithubWebhookListener():
         action = body.get('action')
         pr_body = body.get('pull_request')
 
-        # After github hook is sent, we need to wait for 2s for the cache
-        # in github is synced
-        # This would prevent 404 error when PR changed its state
-        sleep(2)
-        self.log.info("2s sleep for github ref is synced")
         event = self._pull_request_to_event(pr_body)
         event.account = self._get_sender(body)
 


### PR DESCRIPTION
Where it can be applied for all events instead of only the PR creating event